### PR TITLE
Plugin engine refactor

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include satop_platform/default/config/*.yml
+include satop_platform/default/config/*.yaml

--- a/satop_platform/components/groundstation/connector.py
+++ b/satop_platform/components/groundstation/connector.py
@@ -16,8 +16,9 @@ from pydantic import BaseModel
 from satop_platform.components.restapi.restapi import APIApplication
 
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
-    from satop_platform.core.component_initializer import SatOPComponents
+    from satop_platform.core.satop_application import SatOPApplication
 
 logger = logging.getLogger(__name__)
 
@@ -48,9 +49,9 @@ class ResponseQueueItem:
 class GroundstationConnector:
     registered_groundstations: dict[uuid.UUID, GroundstationRegistrationItem]
 
-    def __init__(self, components: SatOPComponents):
+    def __init__(self, app: SatOPApplication):
         self.registered_groundstations = dict()
-        self.__setup_routes(components.api)
+        self.__setup_routes(app.api)
 
     async def __websocket_send(self, gs_id:uuid.UUID, data:dict|FramedContent):
         request_id = uuid.uuid4()

--- a/satop_platform/components/restapi/restapi.py
+++ b/satop_platform/components/restapi/restapi.py
@@ -8,7 +8,7 @@ from satop_platform.core.config import SatopConfig
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from satop_platform.components.authorization.auth import PlatformAuthorization
-    from satop_platform.core.component_initializer import SatOPComponents
+    from satop_platform.core.satop_application import SatOPApplication
 
 logger = logging.getLogger(__name__)
 
@@ -20,13 +20,13 @@ class APIApplication:
     _root_path: str
     _router: APIRouter
 
-    def __init__(self, components:SatOPComponents, *args, **kwargs):
+    def __init__(self, app: SatOPApplication, *args, **kwargs):
         #self._api_config = config.load_config('api.yml')
         self._api_config = SatopConfig('api')
         self._root_path = self._api_config.get('root_path', '/api')
 
         self.api_app = FastAPI(*args, **kwargs)
-        self.authorization = components.auth
+        self.authorization = app.auth
         self._router = APIRouter(prefix=self._root_path)
 
     def mount_plugin_router(self, plugin_name:str, plugin_router: APIRouter, tags: list[str] = None, plugin_path: str=None):

--- a/satop_platform/components/restapi/restapi.py
+++ b/satop_platform/components/restapi/restapi.py
@@ -74,7 +74,7 @@ class APIApplication:
         self.api_app.include_router(self._router)
         
         host = self._api_config.get('host', host)
-        port = self._api_config.get('port', port)
+        port = self._api_config.get_int('port', port)
 
         logger.debug(f"API app: {self.api_app}")
         # logger.debug(f"Listing routes custom: {self.list_routes()}")

--- a/satop_platform/components/syslog/syslog.py
+++ b/satop_platform/components/syslog/syslog.py
@@ -17,7 +17,7 @@ from satop_platform.components.syslog import models
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from satop_platform.core.component_initializer import SatOPComponents
+    from satop_platform.core.satop_application import SatOPApplication
 
 ARTIFACT_DIR = config.get_root_data_folder() / 'artifact_data'
 
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class Syslog:
     db: Engine
-    def __init__(self, components: SatOPComponents):
+    def __init__(self, app: SatOPApplication):
         logger.info('Setting up system logger')
 
         engine_path = config.get_root_data_folder() / 'database/artifacts.db'
@@ -100,7 +100,7 @@ class Syslog:
                 return session.exec(statement).all()
 
 
-        components.api.include_router(router)
+        app.api.include_router(router)
 
     def log_event(self, event: models.Event):
         # TODO: check that the subjects and objects exists (user, system, artifact)

--- a/satop_platform/core/config.py
+++ b/satop_platform/core/config.py
@@ -131,6 +131,12 @@ class SatopConfig:
         # Return a default value if it does not exist in any of the 
         return default
 
+    def get_int(self, key:str, default:int|None)->int|None:
+        try:
+            return int(self.get(key, default))
+        except (ValueError, TypeError):
+            return default
+
 # Function to recursively merge dictionaries
 def merge_dicts(dict1, dict2):
     logger.debug(f"Merging dicts: dict 1: {dict1}, dict2: {dict2}")

--- a/satop_platform/core/satop_application.py
+++ b/satop_platform/core/satop_application.py
@@ -73,6 +73,7 @@ class SatOPApplication:
         routes.load_routes(self)
 
         self.plugin_engine = SatopPluginEngine(self)
+        self.plugin_engine.load_plugins()
     
     def run(self):
         self.event_manager.publish('satop.startup', None)

--- a/satop_platform/core/satop_application.py
+++ b/satop_platform/core/satop_application.py
@@ -2,19 +2,37 @@ import asyncio
 import importlib
 import logging
 import os
+import pathlib
 import subprocess
 
 from satop_platform.components.restapi import routes
 from satop_platform.plugin_engine.plugin_engine import run_engine, stop_engine
 from satop_platform.core import config
 from satop_platform.core.events import SatOPEventManager
+from satop_platform.components.authorization.auth import PlatformAuthorization
+from satop_platform.components.groundstation.connector import GroundstationConnector
+from satop_platform.components.restapi.restapi import APIApplication
+from satop_platform.components.syslog.syslog import Syslog
 
 from .component_initializer import SatOPComponents
 
 class SatOPApplication:
     logger: logging.Logger
-    components: SatOPComponents
     event_manager: SatOPEventManager
+    api: APIApplication
+    auth: PlatformAuthorization
+    syslog: Syslog
+    gs: GroundstationConnector
+
+    # read-only properties
+    @property
+    def data_root(self):
+        return self.__data_root
+
+    @property
+    def version(self):
+        return self.__version
+    
 
     def __init__(self, log_level = 0):
         self.logger = logging.getLogger()
@@ -35,25 +53,26 @@ class SatOPApplication:
 
         self.event_manager = SatOPEventManager()
 
-        data_dir = config.get_root_data_folder()
-        if not data_dir.exists():
-            logging.info(f'Creating data directory {data_dir}')
-            data_dir.mkdir(parents=True)
+        self.__data_root = config.get_root_data_folder()
+        if not self.data_root.exists():
+            logging.info(f'Creating data directory {self.data_root}')
+            self.data_root.mkdir(parents=True)
         
         git_hash = self.get_git_head()
         version_suffix = '-' + git_hash if git_hash else ''
 
         application_title = 'SatOP Platform'
         version = importlib.metadata.version('satop_platform') + version_suffix
+        self.__version = version
 
-        self.components = SatOPComponents(
-            api = {
-                'title': application_title,
-                'version': version
-                }
-        )
+
+        self.auth = PlatformAuthorization()
+        self.api = APIApplication(self, title = application_title, version = version)
+        self.syslog = Syslog(self)
+        self.gs = GroundstationConnector(self)
+
         self.logger.info(f'Initialized platform application {application_title} v{version}')
-        routes.load_routes(self.components)
+        routes.load_routes(self)
     
     def run(self):
         run_engine(self.components, self.event_manager)

--- a/satop_platform/main.py
+++ b/satop_platform/main.py
@@ -6,14 +6,18 @@ def load_args():
     parser = argparse.ArgumentParser('SatOP Platform')
     parser.add_argument('-v', '--verbose', action='count', default=0)
     parser.add_argument('-t', '--test-auth', action='store_true', default=False)
+    parser.add_argument('--install-plugin-requirements', action='store_true', default=False)
     return parser.parse_args()
 
 def main():
     args = load_args()
     if args.test_auth:
         os.environ['SATOP_ENABLE_TEST_AUTH'] = 'True'
-
+    
     application = SatOPApplication(log_level=args.verbose)
+    if args.install_plugin_requirements:
+        application.plugin_engine.install_requirements()
+
     application.run()
 
 if __name__ == '__main__':

--- a/satop_platform/plugin_engine/plugin.py
+++ b/satop_platform/plugin_engine/plugin.py
@@ -4,11 +4,10 @@ from typing import Dict, Iterable
 import logging
 from fastapi import APIRouter
 import yaml
-from satop_platform.components.authorization.auth import PlatformAuthorization
-from satop_platform.components.groundstation.connector import GroundstationConnector
-from satop_platform.components.syslog.syslog import Syslog
-_functions = dict()
 
+# from typing import TYPE_CHECKING
+# if TYPE_CHECKING:
+#     from satop_platform.core.satop_application import SatOPApplication
 
 class Plugin:
     name: str
@@ -16,7 +15,7 @@ class Plugin:
     data_dir: Path
     logger: logging.Logger
     api_router: APIRouter = None
-    sys_log: Syslog = None
+    # app:SatOPApplication
 
     @classmethod
     def register_function(cls, func):
@@ -28,8 +27,7 @@ class Plugin:
         func._register_as_plugin_function = True
         return func
 
-
-    def __init__(self, plugin_dir: str, data_dir: Path = None, platform_auth: PlatformAuthorization = None, gs_connector: GroundstationConnector = None): # TODO: this might be too exposed!
+    def __init__(self, plugin_dir: str, data_dir: Path = None, app=None): # TODO: this might be too exposed!
         """Initializes the plugin with its configuration.
 
         Args:
@@ -43,41 +41,12 @@ class Plugin:
 
         self.config = config
         self.name = config['name']
-        self.platform_auth = platform_auth
-        self.gs_connector = gs_connector
-
+        self.app = app
+        
+        self.platform_auth = app.auth
+        self.gs_connector = app.gs
 
         self.logger = logging.getLogger(__name__ + '.' + self.name)
-        
-        # Discover all methods that have _register_as_plugin_function=True
-        # and register them in the global _functions dict
-        self._discover_and_register()
-
-    def _discover_and_register(self):
-        """
-        Inspects 'self' to find methods flagged by @Plugin.register_function
-        and registers them in the global _functions dict.
-        """
-        # Initialize a dict for this plugin if not present
-        if self.name not in _functions:
-            _functions[self.name] = {}
-
-        for attr_name in dir(self):
-            method = getattr(self, attr_name)
-            if callable(method) and getattr(method, '_register_as_plugin_function', False):
-                func_name = method.__name__
-                if func_name in _functions[self.name]:
-                    raise ValueError(f"Function '{func_name}' already registered by plugin '{self.name}'.")
-                
-                # Register the method in the global registry
-                _functions[self.name][func_name] = method
-                self.logger.debug(f"Registered function '{func_name}' from plugin '{self.name}'.")
-        
-
-    # def _register_funciton(self):
-    #     def decorator(func):
-    #         self.register_function(func.__name__, func)
-    #         return func
 
     def startup(self):
         """
@@ -109,16 +78,7 @@ class Plugin:
             any: Return value of the called function.
         """
 
-        p = _functions.get(plugin_name, None)
-        if p is None:
-            raise ValueError(f"Plugin '{plugin_name}' is not found or has not registered any functions.")
-        
-        f = p.get(func_name, None)
-        if f is None:
-            raise ValueError(f"Function '{func_name}' not found in plugin '{plugin_name}'.")
-
-
-        return f(*args, **kwargs)
+        return self.app.plugin_engine.call_plugin_method(plugin_name, func_name, *args, **kwargs)
 
     def list_functions(self) -> Dict[str, Dict[str, Callable]]:
         """
@@ -127,7 +87,7 @@ class Plugin:
         Returns:
             Dict[str, Dict[str, Callable]]: The entire function registry.
         """
-        return _functions
+        return self.app.plugin_engine.get_registered_plugin_methods()
     
     def check_required_capabilities(self, required: Iterable[str]):
         caps = set(self.config.get('capabilities', []))

--- a/satop_platform/plugin_engine/plugin_engine.py
+++ b/satop_platform/plugin_engine/plugin_engine.py
@@ -1,34 +1,32 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import importlib.util
-from itertools import chain
 import logging
 import os
-from pathlib import Path
 import re
 import subprocess
 import sys
-from collections import defaultdict
 import traceback
-from typing import Optional
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
-import yaml
 import networkx as nx
-from fastapi import APIRouter
+import yaml
 
 import satop_platform.core.config
+from satop_platform.components.restapi import exceptions
 from satop_platform.core.config import merge_dicts
-from satop_platform.components.restapi import APIApplication, exceptions
-from satop_platform.core.events import SatOPEventManager
 from satop_platform.plugin_engine.plugin import AuthenticationProviderPlugin, Plugin
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from satop_platform.core.satop_application import SatOPApplication
 
 # Define terminal logging module
 logger = logging.getLogger(__name__)
+
 
 @dataclass
 class PluginDictItem:
@@ -37,20 +35,21 @@ class PluginDictItem:
     package_name: str
     instance: Optional[Plugin] = None
 
+
 class SatopPluginEngine:
-    _plugins : dict[str, PluginDictItem]
+    _plugins: dict[str, PluginDictItem]
     _load_order: list
     _registered_plugin_methods: dict[str, dict[str, callable]]
     app: SatOPApplication
 
-    def __init__(self, app:SatOPApplication):
+    def __init__(self, app: SatOPApplication):
         self._plugins = dict()
         self._load_order = dict()
         self._registered_plugin_methods = dict()
         self.app = app
-        
+
         logger.debug(self.app.event_manager.subscriptions)
-    
+
     def __del__(self):
         for name, p in self._plugins.items():
             if p.instance:
@@ -58,20 +57,22 @@ class SatopPluginEngine:
                 p.instance = None
 
     def _get_capabilities(self, plugin_name):
-        return self._plugins.get(plugin_name, {}).get('config', {}).get('capabilities', [])
+        return (
+            self._plugins.get(plugin_name, {}).get("config", {}).get("capabilities", [])
+        )
 
-    def _discover_plugins(self, force_rediscover = False):
-        '''
+    def _discover_plugins(self, force_rediscover=False):
+        """
         Expects plugins to be located in the plugins directory
 
         Expects plugin structure as follows
             Package:
             - config.yaml
             - python main-plugin
-        '''
+        """
         file_path = os.path.dirname(os.path.realpath(__file__))
-        default_plugins = Path(os.path.join(file_path, '../..', 'satop_plugins'))
-        user_plugins = satop_platform.core.config.get_root_data_folder()/'plugins'
+        default_plugins = Path(os.path.join(file_path, "../..", "satop_plugins"))
+        user_plugins = satop_platform.core.config.get_root_data_folder() / "plugins"
 
         if self._plugins and not force_rediscover:
             return
@@ -83,38 +84,36 @@ class SatopPluginEngine:
         if user_plugins.as_posix() not in sys.path:
             sys.path.append(user_plugins.as_posix())
 
-        plugin_paths:list[Path] = []
-        for plugin_path in chain(default_plugins.glob('*/'), user_plugins.glob('*/')):
+        plugin_paths: list[Path] = []
+        for plugin_path in chain(default_plugins.glob("*/"), user_plugins.glob("*/")):
             plugin_paths.append(plugin_path.absolute())
 
         for plugin_path in plugin_paths:
             if os.path.isdir(plugin_path):
-                config_path = os.path.join(plugin_path, 'config.yaml')
+                config_path = os.path.join(plugin_path, "config.yaml")
                 if os.path.exists(config_path):
-                    with open(config_path, 'r') as f:
+                    with open(config_path, "r") as f:
                         config = yaml.safe_load(f)
                     assert "name" in config
-                    plugin_name = config.get('name')
+                    plugin_name = config.get("name")
 
                     self._plugins[plugin_name] = PluginDictItem(
-                        config,
-                        plugin_path.as_posix(),
-                        plugin_path.name
+                        config, plugin_path.as_posix(), plugin_path.name
                     )
         logger.info(f"Discovered plugins: {list(self._plugins.keys())}")
 
     def _resolve_dependencies(self):
-        '''
+        """
         Check for dependencies defined in each plugin's config.yaml
-        '''
+        """
         dependency_graph = defaultdict(list)
 
         # Build dependency graph
         for plugin_name, plugin_info in self._plugins.items():
-            dependencies = plugin_info.config.get('dependencies', [])
+            dependencies = plugin_info.config.get("dependencies", [])
             for dep in dependencies:
                 dependency_graph[plugin_name].append(dep)
-        
+
         # Topological sort
         visited = {}
         stack = []
@@ -139,34 +138,35 @@ class SatopPluginEngine:
         logger.info(f"Plugin load order resolved: {self._load_order}")
 
     def _install_requirements(self):
-        '''
+        """
         Check for requirements defined in each plugin's config.yaml and install
-        '''
+        """
         all_requirements = set()
         for plugin_info in self._plugins.values():
-            reqs = set(plugin_info.config.get('requirements', []))
+            reqs = set(plugin_info.config.get("requirements", []))
             all_requirements = all_requirements | reqs
 
         for req in all_requirements:
-            try:    
+            try:
                 logger.info(f"Installing requirements: {all_requirements}")
-                if req.startswith('git+'):
-                    logger.warning(f"Git requirement '{req}' will be upgraded to latest version")
-                    subprocess.check_call(['pip', 'install', '--upgrade', req])
+                if req.startswith("git+"):
+                    logger.warning(
+                        f"Git requirement '{req}' will be upgraded to latest version"
+                    )
+                    subprocess.check_call(["pip", "install", "--upgrade", req])
                 else:
-                    subprocess.check_call(['pip', 'install', req])
+                    subprocess.check_call(["pip", "install", req])
                 logger.info("Successfully installed all requirements.")
             except subprocess.CalledProcessError as e:
                 logger.error(f"Failed to install requirements: {e}")
                 raise
 
     def _load_plugins(self):
-        """Load plugins found during discovery and dependency resolution
-        """
+        """Load plugins found during discovery and dependency resolution"""
 
         failed_plugins = []
         for plugin_name in self._load_order:
-            logger.debug(f'Trying to load {plugin_name}')
+            logger.debug(f"Trying to load {plugin_name}")
             try:
                 plugin_info = self._plugins[plugin_name]
                 package_name = plugin_info.package_name
@@ -174,16 +174,24 @@ class SatopPluginEngine:
 
                 # Dynamically load the plugin module
                 logger.debug(f'Importing plugin package "{package_name}"')
-                module = importlib.import_module(f'{package_name}')
+                module = importlib.import_module(f"{package_name}")
 
                 # Create an instance of the plugin
-                plugin_data_dir = satop_platform.core.config.get_root_data_folder() / 'plugin_data' / plugin_name
-                plugin_instance = module.PluginClass(data_dir=plugin_data_dir, app=self.app)
+                plugin_data_dir = (
+                    satop_platform.core.config.get_root_data_folder()
+                    / "plugin_data"
+                    / plugin_name
+                )
+                plugin_instance = module.PluginClass(
+                    data_dir=plugin_data_dir, app=self.app
+                )
 
                 # Register flagged methods
                 for attr_name in dir(plugin_instance):
                     method = getattr(plugin_instance, attr_name)
-                    if callable(method) and getattr(method, '_register_as_plugin_function', False):
+                    if callable(method) and getattr(
+                        method, "_register_as_plugin_function", False
+                    ):
                         method_name = method.__name__
                         self._register_plugin_method(plugin_name, method_name, method)
 
@@ -191,17 +199,20 @@ class SatopPluginEngine:
                 plugin_info.instance = plugin_instance
                 logger.debug(f"Loaded plugin: {plugin_name}")
 
-
                 # Set the API router, if any
-                caps = config.get('capabilities', [])
+                caps = config.get("capabilities", [])
                 # print(caps)
                 if plugin_instance.api_router:
-                    if 'http.add_routes' in caps:
+                    if "http.add_routes" in caps:
                         self._mount_plugin_router(plugin_instance)
                     else:
-                        logger.warning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
-                        raise RuntimeWarning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
-                if 'security.authentication_provider' in caps:
+                        logger.warning(
+                            f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'"
+                        )
+                        raise RuntimeWarning(
+                            f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'"
+                        )
+                if "security.authentication_provider" in caps:
                     self._register_authentication_plugins(plugin_instance)
 
                 logger.info(f"Loaded plugin: {plugin_name}")
@@ -215,41 +226,43 @@ class SatopPluginEngine:
             logger.debug(f'Will not initialize "{plugin_name}" due to error in loading')
             self._load_order.remove(plugin_name)
             del self._plugins[plugin_name]
-            
 
     def _mount_plugin_router(self, plugin_instance: Plugin):
-        '''
+        """
         Mount the router for a plugin
-        '''
+        """
         router = plugin_instance.api_router
         if router is None:
             return
 
         plugin_name = plugin_instance.name
-        url_friendly_name = plugin_name.lower().replace(' ', '_')
-        url_friendly_name = re.sub(r'[^a-z0-9_]', '', url_friendly_name)
+        url_friendly_name = plugin_name.lower().replace(" ", "_")
+        url_friendly_name = re.sub(r"[^a-z0-9_]", "", url_friendly_name)
 
         if plugin_name != url_friendly_name:
-            logger.warning(f'Path for plugin name "{plugin_name}" has been modified to "{url_friendly_name}" for URL safety and consistency')
+            logger.warning(
+                f'Path for plugin name "{plugin_name}" has been modified to "{url_friendly_name}" for URL safety and consistency'
+            )
 
         num_routes = len(router.routes)
         if num_routes > 0:
             logger.info(f"Plugin '{plugin_name}' has {num_routes} routes. Mounting...")
             self.app.api.mount_plugin_router(url_friendly_name, router)
-            
 
-    def _register_authentication_plugins(self, plugin_instance: AuthenticationProviderPlugin):
+    def _register_authentication_plugins(
+        self, plugin_instance: AuthenticationProviderPlugin
+    ):
         plugin_name = plugin_instance.name
 
         config = self._plugins.get(plugin_name).config
-        provider_config = config.get('authentication_provider')
+        provider_config = config.get("authentication_provider")
 
         provider_key = plugin_name
         identifier_hint = None
 
         if provider_config:
-            provider_key = provider_config.get('provider_key', provider_key)
-            identifier_hint = provider_config.get('identifier_hint', identifier_hint)
+            provider_key = provider_config.get("provider_key", provider_key)
+            identifier_hint = provider_config.get("identifier_hint", identifier_hint)
 
         # Register provider
         self.app.auth.register_provider(provider_key, identifier_hint)
@@ -269,59 +282,65 @@ class SatopPluginEngine:
         G = nx.DiGraph()
         edges = set()
 
-        G.add_node('satop.startup', function=lambda: logger.info('Running plugin start target'))
-        G.add_node('satop.shutdown', function=lambda: logger.info('Running plugin shutdown target'))
+        G.add_node(
+            "satop.startup", function=lambda: logger.info("Running plugin start target")
+        )
+        G.add_node(
+            "satop.shutdown",
+            function=lambda: logger.info("Running plugin shutdown target"),
+        )
 
         target_configs = {
-            p.config.get('name', ''): p.config.get('targets', dict())
-            for p in self._plugins.values() if p
+            p.config.get("name", ""): p.config.get("targets", dict())
+            for p in self._plugins.values()
+            if p
         }
 
         # Go through all plugins to find targets and dependencies (directed edges)
         for name, targets in target_configs.items():
             if not name:
-                logger.error('Plugin config does not have a name. Cannot create targets')
-                raise RuntimeError('Plugin config does not have a name. Cannot create targets')
-            
+                logger.error(
+                    "Plugin config does not have a name. Cannot create targets"
+                )
+                raise RuntimeError(
+                    "Plugin config does not have a name. Cannot create targets"
+                )
+
             # Makes a root for startup and shutdown from which all startup
             #  and shutdown methods, respectfully, must be executed after
             # TODO: protect against malicious shutdown plugins (casuing shutdown to happen pematurely, by linking startup and shutdown)
             target_defaults = {
-                'startup': {
-                    'function': 'startup',
-                    'after': [
-                        'satop.startup'
-                    ]
-                }, 
-                'shutdown': {
-                    'function': 'shutdown',
-                    'after': [
-                        'satop.shutdown'
-                    ]
-                }
+                "startup": {"function": "startup", "after": ["satop.startup"]},
+                "shutdown": {"function": "shutdown", "after": ["satop.shutdown"]},
             }
 
             targets = merge_dicts(target_defaults, targets)
 
             for target_name, details in targets.items():
-                target_id = f'{name}.{target_name}'
+                target_id = f"{name}.{target_name}"
                 function = None
-                function_name = details.get('function', None)
-                if not function_name and target_name not in ['startup', 'shutdown']:
-                    logger.warning(f'No function specified for target "{target_name}" in plugin "{name}"')
-                    raise RuntimeError(f'No function specified for target "{target_name}" in plugin "{name}"')
+                function_name = details.get("function", None)
+                if not function_name and target_name not in ["startup", "shutdown"]:
+                    logger.warning(
+                        f'No function specified for target "{target_name}" in plugin "{name}"'
+                    )
+                    raise RuntimeError(
+                        f'No function specified for target "{target_name}" in plugin "{name}"'
+                    )
                 if function_name:
                     inst = self._plugins.get(name).instance
                     if inst is None:
-                        logger.error(f'Plugin instance not initialized for plugin "{name}"')
-                        raise RuntimeError('Plugin instance not initialized')
+                        logger.error(
+                            f'Plugin instance not initialized for plugin "{name}"'
+                        )
+                        raise RuntimeError("Plugin instance not initialized")
                     function = getattr(inst, function_name)
 
                 G.add_node(target_id, function=function)
 
-                for t in details.get('before', []):
+                for t in details.get("before", []):
                     edges.add((target_id, t))
-                for t in details.get('after', []):
+                for t in details.get("after", []):
                     edges.add((t, target_id))
 
         # Check all edges are valid (targets exist)
@@ -335,10 +354,9 @@ class SatopPluginEngine:
 
             G.add_edge(p, q)
 
-
-        # Ensure no cycles 
+        # Ensure no cycles
         # find all independent graphs
-        # iterate through each and mark visited 
+        # iterate through each and mark visited
         try:
             c = nx.find_cycle(G, orientation="original")
             logger.error(f"Found cycle in graph during target discovery: {c}")
@@ -351,37 +369,45 @@ class SatopPluginEngine:
         trees = dict()
         for component in nx.weakly_connected_components(G):
             G_sub = G.subgraph(component)
-            root = [n for n,d in G_sub.in_degree() if d == 0]
+            root = [n for n, d in G_sub.in_degree() if d == 0]
             if len(root) > 1:
-                logger.error(f'Multiple roots in target graph: {root}')
-            trees[root[0]] = [(node, G.nodes[node]) for node in nx.topological_sort(G_sub)]
+                logger.error(f"Multiple roots in target graph: {root}")
+            trees[root[0]] = [
+                (node, G.nodes[node]) for node in nx.topological_sort(G_sub)
+            ]
 
-        logger.debug(f'Target graph root nodes: {trees.keys()}')
+        logger.debug(f"Target graph root nodes: {trees.keys()}")
 
         return trees
 
-    def _register_plugin_method(self, plugin_name:str, method_name:str, func:callable):
+    def _register_plugin_method(
+        self, plugin_name: str, method_name: str, func: callable
+    ):
         if plugin_name not in self._registered_plugin_methods:
             self._registered_plugin_methods[plugin_name] = dict()
 
         if method_name in self._registered_plugin_methods[plugin_name]:
-            raise ValueError(f"Function '{method_name}' already registered by plugin '{plugin_name}'.")
+            raise ValueError(
+                f"Function '{method_name}' already registered by plugin '{plugin_name}'."
+            )
 
         self._registered_plugin_methods[plugin_name][method_name] = func
-        logger.debug(f"Registered function '{method_name}' from plugin '{plugin_name}'.")
-    
-    def get_plugin_method(self, plugin:str, method:str):
-        return self._registered_plugin_methods.get(plugin,{}).get(method)
+        logger.debug(
+            f"Registered function '{method_name}' from plugin '{plugin_name}'."
+        )
 
-    def call_plugin_method(self, plugin:str, method:str, *args, **kwargs):
-        func = self.get_plugin_method(plugin,method)
+    def get_plugin_method(self, plugin: str, method: str):
+        return self._registered_plugin_methods.get(plugin, {}).get(method)
+
+    def call_plugin_method(self, plugin: str, method: str, *args, **kwargs):
+        func = self.get_plugin_method(plugin, method)
         if func is None:
-            raise RuntimeError(f'Method {plugin}/{method} not found')
+            raise RuntimeError(f"Method {plugin}/{method} not found")
         return func(*args, **kwargs)
-    
+
     def get_registered_plugin_methods(self):
         return self._registered_plugin_methods
-    
+
     def install_requirements(self):
         self._discover_plugins()
         self._install_requirements()
@@ -394,23 +420,25 @@ class SatopPluginEngine:
 
         for root, targets in target_graphs.items():
             self.app.event_manager.subscribe(root, execute_target_callback(targets))
-        
+
 
 def execute_target(graph, target_root):
-    logger.debug(f'Executing graph {target_root}')
+    logger.debug(f"Executing graph {target_root}")
     targets = graph.get(target_root, [])
     for target_name, target_attrs in targets:
-        fun = target_attrs.get('function')
+        fun = target_attrs.get("function")
         if fun:
-            logger.info(f'Running target {target_name}')
+            logger.info(f"Running target {target_name}")
             fun()
+
 
 def execute_target2(targets):
     for target_name, target_attrs in targets:
-        fun = target_attrs.get('function')
+        fun = target_attrs.get("function")
         if fun:
-            logger.info(f'Running target {target_name}')
+            logger.info(f"Running target {target_name}")
             fun()
+
 
 def execute_target_callback(targets):
     return lambda _: execute_target2(targets)

--- a/satop_platform/plugin_engine/plugin_engine.py
+++ b/satop_platform/plugin_engine/plugin_engine.py
@@ -25,14 +25,11 @@ from satop_platform.plugin_engine.plugin import AuthenticationProviderPlugin, Pl
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from satop_platform.core.component_initializer import SatOPComponents
+    from satop_platform.core.satop_application import SatOPApplication
 
 # Define terminal logging module
 logger = logging.getLogger(__name__)
 
-# TODO: Refactor the globals into the main engine method
-
-# Global dictionaries to store plugins and their load order
 @dataclass
 class PluginDictItem:
     config: dict[str, any]
@@ -40,304 +37,326 @@ class PluginDictItem:
     package_name: str
     instance: Optional[Plugin] = None
 
-_plugins : dict[str, PluginDictItem] = {}
-_load_order = []
+class SatopPluginEngine:
+    _plugins : dict[str, PluginDictItem]
+    _load_order: list
+    app: SatOPApplication
 
+    def __init__(self, app:SatOPApplication):
+        self._plugins = dict()
+        self._load_order = dict()
+        self.app = app
 
-def _get_capabilities(plugin_name):
-    return _plugins.get(plugin_name, {}).get('config', {}).get('capabilities', [])
+        self._discover_plugins()
+        self._install_requirements()
+        self._resolve_dependencies()
+        self._load_plugins()
+        target_graphs = self._graph_targets()
 
-
-def _discover_plugins():
-    '''
-    Expects plugins to be located in the plugins directory
-
-    Expects plugin structure as follows
-        Package:
-        - config.yaml
-        - python main-plugin
-    '''
-    file_path = os.path.dirname(os.path.realpath(__file__))
-    default_plugins = Path(os.path.join(file_path, '../..', 'satop_plugins'))
-    user_plugins = satop_platform.core.config.get_root_data_folder()/'plugins'
-    
-    sys.path.append(default_plugins.as_posix())
-    sys.path.append(user_plugins.as_posix())
-
-    plugin_paths:list[Path] = []
-    for plugin_path in chain(default_plugins.glob('*/'), user_plugins.glob('*/')):
-        plugin_paths.append(plugin_path.absolute())
-
-    for plugin_path in plugin_paths:
-        if os.path.isdir(plugin_path):
-            config_path = os.path.join(plugin_path, 'config.yaml')
-            if os.path.exists(config_path):
-                with open(config_path, 'r') as f:
-                    config = yaml.safe_load(f)
-                assert "name" in config
-                plugin_name = config.get('name')
-
-                _plugins[plugin_name] = PluginDictItem(
-                    config,
-                    plugin_path.as_posix(),
-                    plugin_path.name
-                )
-    logger.info(f"Discovered plugins: {list(_plugins.keys())}")
-
-def _resolve_dependencies():
-    '''
-    Check for dependencies defined in each plugin's config.yaml
-    '''
-    dependency_graph = defaultdict(list)
-
-    # Build dependency graph
-    for plugin_name, plugin_info in _plugins.items():
-        dependencies = plugin_info.config.get('dependencies', [])
-        for dep in dependencies:
-            dependency_graph[plugin_name].append(dep)
-    
-    # Topological sort
-    visited = {}
-    stack = []
-
-    def visit(node):
-        if node in visited:
-            if not visited[node]:
-                raise Exception(f"Circular dependency detected at {node}")
-            return
-        visited[node] = False
-        for neighbor in dependency_graph.get(node, []):
-            if neighbor not in _plugins:
-                raise Exception(f"Missing dependency: {neighbor} for plugin {node}")
-            visit(neighbor)
-        visited[node] = True
-        stack.append(node)
-
-    for plugin in _plugins:
-        visit(plugin)
-
-    global _load_order
-    _load_order = stack
-    logger.info(f"Plugin load order resolved: {_load_order}")
-
-def _install_requirements():
-    '''
-    Check for requirements defined in each plugin's config.yaml and install
-    '''
-    all_requirements = []
-    for plugin_info in _plugins.values():
-        reqs = plugin_info.config.get('requirements', [])
-        all_requirements.extend(reqs)
-    
-    for req in all_requirements:
-        try:    
-            logger.info(f"Installing requirements: {all_requirements}")
-            if req.startswith('git+'):
-                logger.warning(f"Git requirement '{req}' will be upgraded to latest version")
-                subprocess.check_call(['pip', 'install', '--upgrade', req])
-            else:
-                subprocess.check_call(['pip', 'install', req])
-            logger.info("Successfully installed all requirements.")
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to install requirements: {e}")
-            raise
-
-def _load_plugins(components: SatOPComponents):
-    """Load plugins found during discovery and dependency resolution
-    """
-    api = components.api
-    sysLog = components.syslog
-    platform_auth = components.auth  # TODO: this might be too exposed!
-    gs_connector = components.gs     # TODO: this too, might be too exposed!
-
-    failed_plugins = []
-    for plugin_name in _load_order:
-        logger.debug(f'Trying to load {plugin_name}')
-        try:
-            plugin_info = _plugins[plugin_name]
-            package_name = plugin_info.package_name
-            config = plugin_info.config
-
-            # Dynamically load the plugin module
-            logger.debug(f'Importing plugin package "{package_name}"')
-            module = importlib.import_module(f'{package_name}')
-
-            # Create an instance of the plugin
-            plugin_data_dir = satop_platform.core.config.get_root_data_folder() / 'plugin_data' / plugin_name
-            plugin_instance = module.PluginClass(data_dir=plugin_data_dir, platform_auth=platform_auth, gs_connector=gs_connector)
-
-            # Store the plugin instance before initialization
-            plugin_info.instance = plugin_instance
-            logger.debug(f"Loaded plugin: {plugin_name}")
-            
-            # Set the sys_log
-            plugin_info.instance.sys_log = sysLog
-
-            # Set the API router, if any
-            caps = config.get('capabilities', [])
-            # print(caps)
-            if plugin_instance.api_router:
-                if 'http.add_routes' in caps:
-                    _mount_plugin_router(plugin_instance, api)
-                else:
-                    logger.warning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
-                    raise RuntimeWarning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
-            if 'security.authentication_provider' in caps:
-                _register_authentication_plugins(plugin_instance, api)
-
-            logger.info(f"Loaded plugin: {plugin_name}")
-        except Exception as e:
-            logger.error(f"Failed to load plugin '{plugin_name}': {e}")
-            print(traceback.format_exc())
-            failed_plugins.append(plugin_name)
-
-    for plugin_name in failed_plugins:
-        logger.debug(f'Will not initialize "{plugin_name}" due to error in loading')
-        _load_order.remove(plugin_name)
-        del _plugins[plugin_name]
-            
-
-def _mount_plugin_router(plugin_instance: Plugin, api: APIApplication):
-    '''
-    Mount the router for a plugin
-    '''
-    router = plugin_instance.api_router
-    if router is None:
-        return
-
-    plugin_name = plugin_instance.name
-    url_friendly_name = plugin_name.lower().replace(' ', '_')
-    url_friendly_name = re.sub(r'[^a-z0-9_]', '', url_friendly_name)
-
-    if plugin_name != url_friendly_name:
-        logger.warning(f'Path for plugin name "{plugin_name}" has been modified to "{url_friendly_name}" for URL safety and consistency')
-
-    num_routes = len(router.routes)
-    if num_routes > 0:
-        logger.info(f"Plugin '{plugin_name}' has {num_routes} routes. Mounting...")
-        api.mount_plugin_router(url_friendly_name, router)
-
-def _register_authentication_plugins(plugin_instance: AuthenticationProviderPlugin, api: APIApplication):
-    plugin_name = plugin_instance.name
-
-    config = _plugins.get(plugin_name).config
-    provider_config = config.get('authentication_provider')
-
-    provider_key = plugin_name
-    identifier_hint = None
-
-    if provider_config:
-        provider_key = provider_config.get('provider_key', provider_key)
-        identifier_hint = provider_config.get('identifier_hint', identifier_hint)
-
-    # Register provider
-    api.authorization.register_provider(provider_key, identifier_hint)
-
-    def _get_auth_token(user_id: str):
-        # Get uuid
-        uuid = api.authorization.get_uuid(provider_key, user_id)
-        if not uuid:
-            raise exceptions.InvalidCredentials
-        # TODO: Make it possible for plugin to specify expiry, e.g. for long-lived application keys
-        token = api.authorization.create_token(uuid)
-        return token
-
-    _plugins.get(plugin_name).instance.create_auth_token = _get_auth_token
-
-def _graph_targets() -> dict[str, list[callable]]:
-    G = nx.DiGraph()
-    edges = set()
-
-    G.add_node('satop.startup', function=lambda: logger.info('Running plugin start target'))
-    G.add_node('satop.shutdown', function=lambda: logger.info('Running plugin shutdown target'))
-
-    target_configs = {
-        p.config.get('name', ''): p.config.get('targets', dict())
-        for p in _plugins.values() if p
-    }
-
-    # Go through all plugins to find targets and dependencies (directed edges)
-    for name, targets in target_configs.items():
-        if not name:
-            logger.error('Plugin config does not have a name. Cannot create targets')
-            raise RuntimeError('Plugin config does not have a name. Cannot create targets')
+        for root, targets in target_graphs.items():
+            self.app.event_manager.subscribe(root, execute_target_callback(targets))
         
-        # Makes a root for startup and shutdown from which all startup
-        #  and shutdown methods, respectfully, must be executed after
-        # TODO: protect against malicious shutdown plugins (casuing shutdown to happen pematurely, by linking startup and shutdown)
-        target_defaults = {
-            'startup': {
-                'function': 'startup',
-                'after': [
-                    'satop.startup'
-                ]
-            }, 
-            'shutdown': {
-                'function': 'shutdown',
-                'after': [
-                    'satop.shutdown'
-                ]
-            }
+        logger.debug(self.app.event_manager.subscriptions)
+    
+    def __del__(self):
+        for name, p in self._plugins.items():
+            if p.instance:
+                del p.instance
+                p.instance = None
+
+    def _get_capabilities(self, plugin_name):
+        return self._plugins.get(plugin_name, {}).get('config', {}).get('capabilities', [])
+
+    def _discover_plugins(self):
+        '''
+        Expects plugins to be located in the plugins directory
+
+        Expects plugin structure as follows
+            Package:
+            - config.yaml
+            - python main-plugin
+        '''
+        file_path = os.path.dirname(os.path.realpath(__file__))
+        default_plugins = Path(os.path.join(file_path, '../..', 'satop_plugins'))
+        user_plugins = satop_platform.core.config.get_root_data_folder()/'plugins'
+        
+        sys.path.append(default_plugins.as_posix())
+        sys.path.append(user_plugins.as_posix())
+
+        plugin_paths:list[Path] = []
+        for plugin_path in chain(default_plugins.glob('*/'), user_plugins.glob('*/')):
+            plugin_paths.append(plugin_path.absolute())
+
+        for plugin_path in plugin_paths:
+            if os.path.isdir(plugin_path):
+                config_path = os.path.join(plugin_path, 'config.yaml')
+                if os.path.exists(config_path):
+                    with open(config_path, 'r') as f:
+                        config = yaml.safe_load(f)
+                    assert "name" in config
+                    plugin_name = config.get('name')
+
+                    self._plugins[plugin_name] = PluginDictItem(
+                        config,
+                        plugin_path.as_posix(),
+                        plugin_path.name
+                    )
+        logger.info(f"Discovered plugins: {list(self._plugins.keys())}")
+
+    def _resolve_dependencies(self):
+        '''
+        Check for dependencies defined in each plugin's config.yaml
+        '''
+        dependency_graph = defaultdict(list)
+
+        # Build dependency graph
+        for plugin_name, plugin_info in self._plugins.items():
+            dependencies = plugin_info.config.get('dependencies', [])
+            for dep in dependencies:
+                dependency_graph[plugin_name].append(dep)
+        
+        # Topological sort
+        visited = {}
+        stack = []
+
+        def visit(node):
+            if node in visited:
+                if not visited[node]:
+                    raise Exception(f"Circular dependency detected at {node}")
+                return
+            visited[node] = False
+            for neighbor in dependency_graph.get(node, []):
+                if neighbor not in self._plugins:
+                    raise Exception(f"Missing dependency: {neighbor} for plugin {node}")
+                visit(neighbor)
+            visited[node] = True
+            stack.append(node)
+
+        for plugin in self._plugins:
+            visit(plugin)
+
+        self._load_order = stack
+        logger.info(f"Plugin load order resolved: {self._load_order}")
+
+    def _install_requirements(self):
+        '''
+        Check for requirements defined in each plugin's config.yaml and install
+        '''
+        all_requirements = []
+        for plugin_info in self._plugins.values():
+            reqs = plugin_info.config.get('requirements', [])
+            all_requirements.extend(reqs)
+        
+        for req in all_requirements:
+            try:    
+                logger.info(f"Installing requirements: {all_requirements}")
+                if req.startswith('git+'):
+                    logger.warning(f"Git requirement '{req}' will be upgraded to latest version")
+                    subprocess.check_call(['pip', 'install', '--upgrade', req])
+                else:
+                    subprocess.check_call(['pip', 'install', req])
+                logger.info("Successfully installed all requirements.")
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed to install requirements: {e}")
+                raise
+
+    def _load_plugins(self):
+        """Load plugins found during discovery and dependency resolution
+        """
+
+        failed_plugins = []
+        for plugin_name in self._load_order:
+            logger.debug(f'Trying to load {plugin_name}')
+            try:
+                plugin_info = self._plugins[plugin_name]
+                package_name = plugin_info.package_name
+                config = plugin_info.config
+
+                # Dynamically load the plugin module
+                logger.debug(f'Importing plugin package "{package_name}"')
+                module = importlib.import_module(f'{package_name}')
+
+                # Create an instance of the plugin
+                plugin_data_dir = satop_platform.core.config.get_root_data_folder() / 'plugin_data' / plugin_name
+                plugin_instance = module.PluginClass(data_dir=plugin_data_dir, platform_auth=self.app.auth, gs_connector=self.app.gs)
+
+                # Store the plugin instance before initialization
+                plugin_info.instance = plugin_instance
+                logger.debug(f"Loaded plugin: {plugin_name}")
+                
+                # Set the sys_log
+                plugin_info.instance.sys_log = self.app.syslog
+
+                # Set the API router, if any
+                caps = config.get('capabilities', [])
+                # print(caps)
+                if plugin_instance.api_router:
+                    if 'http.add_routes' in caps:
+                        self._mount_plugin_router(plugin_instance)
+                    else:
+                        logger.warning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
+                        raise RuntimeWarning(f"{plugin_name} has created a route but does not have the required capabilities to mount it. Ensure it has 'http.add_routes' in the plugin's 'config.yaml'")
+                if 'security.authentication_provider' in caps:
+                    self._register_authentication_plugins(plugin_instance)
+
+                logger.info(f"Loaded plugin: {plugin_name}")
+            except Exception as e:
+                logger.error(f"Failed to load plugin '{plugin_name}': {e}")
+                print(traceback.format_exc())
+                failed_plugins.append(plugin_name)
+
+        for plugin_name in failed_plugins:
+            logger.debug(f'Will not initialize "{plugin_name}" due to error in loading')
+            self._load_order.remove(plugin_name)
+            del self._plugins[plugin_name]
+            
+
+    def _mount_plugin_router(self, plugin_instance: Plugin):
+        '''
+        Mount the router for a plugin
+        '''
+        router = plugin_instance.api_router
+        if router is None:
+            return
+
+        plugin_name = plugin_instance.name
+        url_friendly_name = plugin_name.lower().replace(' ', '_')
+        url_friendly_name = re.sub(r'[^a-z0-9_]', '', url_friendly_name)
+
+        if plugin_name != url_friendly_name:
+            logger.warning(f'Path for plugin name "{plugin_name}" has been modified to "{url_friendly_name}" for URL safety and consistency')
+
+        num_routes = len(router.routes)
+        if num_routes > 0:
+            logger.info(f"Plugin '{plugin_name}' has {num_routes} routes. Mounting...")
+            self.app.api.mount_plugin_router(url_friendly_name, router)
+            
+
+    def _register_authentication_plugins(self, plugin_instance: AuthenticationProviderPlugin):
+        plugin_name = plugin_instance.name
+
+        config = self._plugins.get(plugin_name).config
+        provider_config = config.get('authentication_provider')
+
+        provider_key = plugin_name
+        identifier_hint = None
+
+        if provider_config:
+            provider_key = provider_config.get('provider_key', provider_key)
+            identifier_hint = provider_config.get('identifier_hint', identifier_hint)
+
+        # Register provider
+        self.app.auth.register_provider(provider_key, identifier_hint)
+
+        def _get_auth_token(user_id: str):
+            # Get uuid
+            uuid = self.app.api.authorization.get_uuid(provider_key, user_id)
+            if not uuid:
+                raise exceptions.InvalidCredentials
+            # TODO: Make it possible for plugin to specify expiry, e.g. for long-lived application keys
+            token = self.app.api.authorization.create_token(uuid)
+            return token
+
+        self._plugins.get(plugin_name).instance.create_auth_token = _get_auth_token
+
+    def _graph_targets(self) -> dict[str, list[callable]]:
+        G = nx.DiGraph()
+        edges = set()
+
+        G.add_node('satop.startup', function=lambda: logger.info('Running plugin start target'))
+        G.add_node('satop.shutdown', function=lambda: logger.info('Running plugin shutdown target'))
+
+        target_configs = {
+            p.config.get('name', ''): p.config.get('targets', dict())
+            for p in self._plugins.values() if p
         }
 
-        targets = merge_dicts(target_defaults, targets)
+        # Go through all plugins to find targets and dependencies (directed edges)
+        for name, targets in target_configs.items():
+            if not name:
+                logger.error('Plugin config does not have a name. Cannot create targets')
+                raise RuntimeError('Plugin config does not have a name. Cannot create targets')
+            
+            # Makes a root for startup and shutdown from which all startup
+            #  and shutdown methods, respectfully, must be executed after
+            # TODO: protect against malicious shutdown plugins (casuing shutdown to happen pematurely, by linking startup and shutdown)
+            target_defaults = {
+                'startup': {
+                    'function': 'startup',
+                    'after': [
+                        'satop.startup'
+                    ]
+                }, 
+                'shutdown': {
+                    'function': 'shutdown',
+                    'after': [
+                        'satop.shutdown'
+                    ]
+                }
+            }
 
-        for target_name, details in targets.items():
-            target_id = f'{name}.{target_name}'
-            function = None
-            function_name = details.get('function', None)
-            if not function_name and target_name not in ['startup', 'shutdown']:
-                logger.warning(f'No function specified for target "{target_name}" in plugin "{name}"')
-                raise RuntimeError(f'No function specified for target "{target_name}" in plugin "{name}"')
-            if function_name:
-                inst = _plugins.get(name).instance
-                if inst is None:
-                    logger.error(f'Plugin instance not initialized for plugin "{name}"')
-                    raise RuntimeError('Plugin instance not initialized')
-                function = getattr(inst, function_name)
+            targets = merge_dicts(target_defaults, targets)
 
-            G.add_node(target_id, function=function)
+            for target_name, details in targets.items():
+                target_id = f'{name}.{target_name}'
+                function = None
+                function_name = details.get('function', None)
+                if not function_name and target_name not in ['startup', 'shutdown']:
+                    logger.warning(f'No function specified for target "{target_name}" in plugin "{name}"')
+                    raise RuntimeError(f'No function specified for target "{target_name}" in plugin "{name}"')
+                if function_name:
+                    inst = self._plugins.get(name).instance
+                    if inst is None:
+                        logger.error(f'Plugin instance not initialized for plugin "{name}"')
+                        raise RuntimeError('Plugin instance not initialized')
+                    function = getattr(inst, function_name)
 
-            for t in details.get('before', []):
-                edges.add((target_id, t))
-            for t in details.get('after', []):
-                edges.add((t, target_id))
+                G.add_node(target_id, function=function)
 
-    # Check all edges are valid (targets exist)
-    for p, q in edges:
-        if not G.has_node(p):
-            logger.error(f'Target graph is missing node "{p}" ({p} -> {q})')
-            raise RuntimeWarning(f'Target graph is missing node "{p}" ({p} -> {q})')
-        if not G.has_node(q):
-            logger.error(f'Target graph is missing node "{q}" ({p} -> {q})')
-            raise RuntimeWarning(f'Target graph is missing node "{q}" ({p} -> {q})')
+                for t in details.get('before', []):
+                    edges.add((target_id, t))
+                for t in details.get('after', []):
+                    edges.add((t, target_id))
 
-        G.add_edge(p, q)
+        # Check all edges are valid (targets exist)
+        for p, q in edges:
+            if not G.has_node(p):
+                logger.error(f'Target graph is missing node "{p}" ({p} -> {q})')
+                raise RuntimeWarning(f'Target graph is missing node "{p}" ({p} -> {q})')
+            if not G.has_node(q):
+                logger.error(f'Target graph is missing node "{q}" ({p} -> {q})')
+                raise RuntimeWarning(f'Target graph is missing node "{q}" ({p} -> {q})')
+
+            G.add_edge(p, q)
 
 
-    # Ensure no cycles 
-    # find all independent graphs
-    # iterate through each and mark visited 
-    try:
-        c = nx.find_cycle(G, orientation="original")
-        logger.error(f"Found cycle in graph during target discovery: {c}")
-        raise RuntimeError(f"Found cycle in graph during target discovery: {c}")
-    except nx.NetworkXNoCycle:
-        # No cycle found
-        pass
+        # Ensure no cycles 
+        # find all independent graphs
+        # iterate through each and mark visited 
+        try:
+            c = nx.find_cycle(G, orientation="original")
+            logger.error(f"Found cycle in graph during target discovery: {c}")
+            raise RuntimeError(f"Found cycle in graph during target discovery: {c}")
+        except nx.NetworkXNoCycle:
+            # No cycle found
+            pass
 
-    # Create shutdown and startup call lists
-    trees = dict()
-    for component in nx.weakly_connected_components(G):
-        G_sub = G.subgraph(component)
-        root = [n for n,d in G_sub.in_degree() if d == 0]
-        if len(root) > 1:
-            logger.error(f'Multiple roots in target graph: {root}')
-        trees[root[0]] = [(node, G.nodes[node]) for node in nx.topological_sort(G_sub)]
+        # Create shutdown and startup call lists
+        trees = dict()
+        for component in nx.weakly_connected_components(G):
+            G_sub = G.subgraph(component)
+            root = [n for n,d in G_sub.in_degree() if d == 0]
+            if len(root) > 1:
+                logger.error(f'Multiple roots in target graph: {root}')
+            trees[root[0]] = [(node, G.nodes[node]) for node in nx.topological_sort(G_sub)]
 
-    logger.debug(f'Target graph root nodes: {trees.keys()}')
+        logger.debug(f'Target graph root nodes: {trees.keys()}')
 
-    return trees
+        return trees
+    
+    def startup(self):
+        self.app.event_manager.publish('satop.startup', None)
+        
 
 def execute_target(graph, target_root):
     logger.debug(f'Executing graph {target_root}')
@@ -357,36 +376,3 @@ def execute_target2(targets):
 
 def execute_target_callback(targets):
     return lambda _: execute_target2(targets)
-
-
-def run_engine(components: SatOPComponents, event_manager: SatOPEventManager):
-    '''
-    Discover all plugins in the "plugins" directory (expected to be located in root satop_platform directory)
-
-    Install all plugin requirements and check for dependencies
-
-    Load and initialize all plugins in "plugins" directory
-    '''
-    _discover_plugins()
-    _install_requirements()
-    _resolve_dependencies()
-    _load_plugins(components)
-    target_graphs = _graph_targets()
-
-    for root, targets in target_graphs.items():
-        event_manager.subscribe(root, execute_target_callback(targets))
-    
-    logger.debug(event_manager.subscriptions)
-
-    # execute_target(target_graphs, 'satop.startup')
-    event_manager.publish('satop.startup', None)
-
-
-def stop_engine(event_manager: SatOPEventManager):
-    event_manager.publish('satop.shutdown', None)
-
-    for name, p in _plugins.items():
-        if p.instance:
-            del p.instance
-            p.instance = None
-


### PR DESCRIPTION
Refactored the plugin engine as a class:

- The plugin engine now receives the SatOPApplication object, and sets it directly in the plugins as the "app"-attribute. Legacy attributes "platform_auth" and "gs_connector" is still set, even though they can now also be accessed through self.app.
- Internal logic of the inter-plugin method calls have been moved from the plugin class to the engine
- Plugin requirements are now not installed/updated on launch by default. Run the platform with "--install-plugin-requirements" to do the requirement installation. 

closes #13